### PR TITLE
Utilize test_depend that is defined in REP-140

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,10 +14,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>python-catkin-pkg</build_depend>
-  <build_depend>rostest</build_depend>
   <run_depend>rosbridge_server</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rospack</run_depend>
+  <test_depend>rostest</test_depend>
   <export>
     <rosdoc config="rosdoc.yaml" />
   </export>


### PR DESCRIPTION
Looks like using `test_depend` is more appropriate than build_depend, after [REP-140](http://www.ros.org/reps/rep-0140.html) got [implemented for Groovy and later](http://lists.ros.org/lurker/message/20141003.232955.5710a2bf.da.html).
