### PR TITLE
Enable client testing && fix redirect bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,30 +13,17 @@ notifications:
       - gm130s@gmail.com
 env:
   global:
+    - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     # install geckodriver for testing
     - ADDITIONAL_DEBS="firefox"
     - BEFORE_SCRIPT="wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="indigo" PRERELEASE=true
-    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="jade"   PRERELEASE=true
-    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="kinetic"  PRERELEASE=true
-    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar"  PRERELEASE=true
+    - ROS_DISTRO="indigo"
+    - ROS_DISTRO="jade"
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="lunar"
 matrix:
-  allow_failures:
-    - env: ROS_DISTRO="indigo" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
-    - env: ROS_DISTRO="jade"   PRERELEASE=true
-    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
-    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - env: ROS_DISTRO="lunar"  PRERELEASE=true
+  fast_finish: true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ notifications:
     recipients:
       - gm130s@gmail.com
 env:
+  global:
+    # install geckodriver for testing
+    - ADDITIONAL_DEBS="firefox"
+    - BEFORE_SCRIPT="wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
   matrix:
     - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu

--- a/launch/roswww.launch
+++ b/launch/roswww.launch
@@ -1,9 +1,13 @@
 <launch>
   <arg name="name" default="roswww"/>
-  <arg name="port" default="8085"/> <!-- avoid to use apache default port -->
   <arg name="webpath" default="www"/> <!-- package webroot -->
   <arg name="cached" default="true"/>
 
-  <node pkg="roswww" type="webserver.py" name="$(arg name)" args="--name $(arg name) --port $(arg port) --webpath $(arg webpath) --cached $(arg cached)">
-  </node>
+  <arg name="port" default="8085"/>
+  <arg name="start_port" default="$(arg port)" />
+  <arg name="end_port" default="$(arg port)" />
+
+  <node pkg="roswww" type="webserver.py" name="$(arg name)"
+        args="--name $(arg name) --webpath $(arg webpath) --cached $(arg cached)
+              --port $(arg port) --start_port $(arg start_port) --end_port $(arg end_port)" />
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   <run_depend>rosbridge_server</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rospack</run_depend>
-  <test_depend>python-requests</test_depend>
   <test_depend>phantomjs</test_depend>
   <test_depend>python-selenium-pip</test_depend>
   <test_depend>rostest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <run_depend>rosgraph</run_depend>
   <run_depend>rospack</run_depend>
   <test_depend>python-requests</test_depend>
+  <test_depend>phantomjs</test_depend>
+  <test_depend>python-selenium-pip</test_depend>
   <test_depend>rostest</test_depend>
   <export>
     <rosdoc config="rosdoc.yaml" />

--- a/script/webserver.py
+++ b/script/webserver.py
@@ -34,35 +34,31 @@
 #
 # Author: Jonathan Mace, Jihoon Lee, Isaac Isao Saito
 
-import sys
 import argparse
 import roswww
-import rosgraph
+import rospy
+
 
 def parse_argument(argv):
     """
     argument parser for roswww server configuration
     """
     parser = argparse.ArgumentParser(description="ROSWWW Server")
-    parser.add_argument('-n', '--name', default='80', help='Webserver name')
-    parser.add_argument('-p', '--port', default='80', help='Webserver Port number')
+    parser.add_argument('-n', '--name', default=rospy.get_name(), help='Webserver name')
+    parser.add_argument('-p', '--port', default=80, type=int, help='Webserver Port number')
     parser.add_argument('-w', '--webpath', default='www', help='package relative path to web pages')
     parser.add_argument('--cached', default='true', help='static file is cached')
-    parser.add_argument('--start_port', default='8000', help='setting up port scan range')
-    parser.add_argument('--end_port', default='9000', help='setting up port scan range')
+    parser.add_argument('--start_port', default=8000, type=int, help='setting up port scan range')
+    parser.add_argument('--end_port', default=9000, type=int, help='setting up port scan range')
 
-    myargs = rosgraph.myargv(sys.argv[1:]) # strips ros arguements
-    parsed_args = parser.parse_args(myargs)
-
-    return parsed_args.name, parsed_args.webpath, (parsed_args.port, parsed_args.start_port, parsed_args.end_port), parsed_args.cached
+    parsed_args = parser.parse_args(argv)
+    cached = False if parsed_args.cached in [0, False, 'false', 'False'] else True
+    return parsed_args.name, parsed_args.webpath, (parsed_args.port, parsed_args.start_port, parsed_args.end_port), cached
 
 
 if __name__ == '__main__':
-    argv = sys.argv
-    name, webpath, port, cached = parse_argument(argv[1:])
-
-    cached = False if cached in [0, False, 'false', 'False'] else True
-
+    rospy.init_node("webserver", disable_signals=True)
+    name, webpath, port, cached = parse_argument(rospy.myargv()[1:])
     webserver = roswww.ROSWWWServer(name, webpath, port, cached)
     webserver.loginfo("Initialised")
     webserver.spin()

--- a/src/roswww/roswww_server.py
+++ b/src/roswww/roswww_server.py
@@ -72,10 +72,17 @@ class ROSWWWServer():
         handlers = [(r"/", WebRequestHandler, {"packages": packages})]
 
         for package in packages:
-            handler_root = ("/" + package['name'] + "/?()",
+            handler_root = ("/" + package['name'] + "/()",
                             file_handler,
                             {"path": package['path'] + "/" + self._webpath + "/index.html"})
             handlers.append(handler_root)
+
+            # redirect '/<package>' -> /<package>/'
+            handler = ('/' + package['name'],
+                       tornado.web.RedirectHandler,
+                       {'url': '/' + package['name'] + '/'})
+            handlers.append(handler)
+
             handler = ("/" + package['name'] + "/(.*)",
                        file_handler,
                        {"path": package['path'] + "/" + self._webpath,

--- a/test/test_roswww.py
+++ b/test/test_roswww.py
@@ -36,11 +36,13 @@
 # Author: Isaac I.Y. Saito
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
+import os
 import rospy
 import rostest
 import unittest
 
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -51,13 +53,17 @@ class TestClient(unittest.TestCase):
     def setUp(self):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
-        import warnings
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
+        try:
+            opts = webdriver.firefox.options.Options()
+            opts.set_headless(True)
+            self.browser = webdriver.Firefox(firefox_options=opts)
+        except WebDriverException:
+            rospy.logwarn("Failling back to PhantomJS driver")
             self.browser = webdriver.PhantomJS()
-            self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)
-            # maximize screen
-            self.browser.find_element_by_tag_name("html").send_keys(Keys.F11)
+
+        self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)
+        # maximize screen
+        self.browser.find_element_by_tag_name("html").send_keys(Keys.F11)
 
     def tearDown(self):
         try:

--- a/test/test_roswww.py
+++ b/test/test_roswww.py
@@ -34,51 +34,63 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # Author: Isaac I.Y. Saito
-
-import requests
-from requests import ConnectionError
-import unittest
+# Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
 import rospy
 import rostest
+import unittest
 
-from roswww.roswww_server import ROSWWWServer
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
-_PKG = 'roswww'
 
+class TestClient(unittest.TestCase):
 
-class TestRoswww(unittest.TestCase):
-    '''    '''
+    def setUp(self):
+        self.url_base = rospy.get_param("url_roswww_testserver")
 
-    @classmethod
-    def setUpClass(cls):
-        ''' Assume roswww server is not running'''
-        True
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.browser = webdriver.PhantomJS()
+            self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)
+            # maximize screen
+            self.browser.find_element_by_tag_name("html").send_keys(Keys.F11)
 
-    @classmethod
-    def tearDownClass(cls):
-        True
-
-    def _is_wwwserver_running(self):
-        rest = None
-        url = rospy.get_param('url_roswww_testserver')
-        rospy.loginfo('URL used for the server: {}'.format(url))
-        print('URL used for the server: {}'.format(url))
+    def tearDown(self):
         try:
-            rest = requests.get(url)
-        except ConnectionError:
-            rospy.logerr('http request failed.')
+            self.browser.close()
+            self.browser.quit()
+        except:
+            pass
 
-        self.assertIsNotNone(rest)
+    def _check_index(self, url):
+        rospy.logwarn("Accessing to %s" % url)
 
-    def test_roswww_by_launch(self):
-        ''' Test if roswww server is running, ensured by downloading index.htm'''
-        self._is_wwwserver_running()
+        self.browser.get(url)
+        self.wait.until(EC.presence_of_element_located((By.ID, "title")))
 
-    def test_roswww_by_pythonmod(self):
-        ''' Test if roswww server is running, which is run via Python module'''
-        ROSWWWServer('test_roswwww_py', 'www', '8086', True)
-        self._is_wwwserver_running()
+        title = self.browser.find_element_by_id("title")
+        self.assertIsNotNone(title, "Object id=title not found")
+
+        # check load other resouces
+        self.wait.until(EC.presence_of_element_located((By.ID, "relative-link-check")))
+        check = self.browser.find_element_by_id("relative-link-check")
+        self.assertIsNotNone(check, "Object id=relative-link-check not found")
+        self.assertEqual(check.text, "Relative link is loaded",
+                         "Loading 'css/index.css' from 'index.html' failed")
+
+    def test_index_served(self):
+        url = '%s/roswww/' % (self.url_base)
+        self._check_index(url)
+
+    def test_index_redirected(self):
+        url = '%s/roswww' % (self.url_base)
+        self._check_index(url)
+
 
 if __name__ == '__main__':
-    rostest.rosrun(_PKG, 'test_roswww', TestRoswww)
+    rospy.init_node("test_client")
+    exit(rostest.rosrun("roswww", "test_client", TestClient))

--- a/www/css/index.css
+++ b/www/css/index.css
@@ -1,0 +1,11 @@
+h1 {
+    padding: 0.4em 0.5em;
+    color: #494949;
+    background: #f4f4f4;
+    border-left: solid 5px #7db4e6;
+    border-bottom: solid 3px #d7d7d7;
+}
+
+h3 {
+    width: 100%;
+}

--- a/www/index.html
+++ b/www/index.html
@@ -1,3 +1,23 @@
 <html>
-<body>roswww, sup?</body>
+  <head>
+    <title>roswww</title>
+    <meta charset="utf-8" />
+    <link href="css/index.css" rel="stylesheet">
+  </head>
+  <body>
+    <h1 id="title">roswww, sup?</h1>
+    <h3 id="relative-link-check">Relative link check displays here</h3>
+    <script>
+     window.onload = function() {
+       var title = document.getElementById("title");
+       var check = document.getElementById("relative-link-check");
+       var bgColor = window.getComputedStyle(title).backgroundColor.match(/\d+/g);
+       if (bgColor[0] != 244) {
+         check.innerText = "Relative link is not loaded";
+       } else {
+         check.innerText = "Relative link is loaded";
+       }
+      };
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Currently, the test may fail since `roswww` server port is decided randomly range from `--start_port` to `--end_port`.
This pull request adds arguments to set `start_port` and `end_port` to `webserver.launch` file and set them as same as `--port` to fix the port to one specified in here: https://github.com/tork-a/roswww/blob/develop/test/launch.test#L3

I also improved argument parser of server script.

This pull request also include client side test.
To check the error mentioned here: https://github.com/tork-a/visualization_rwt/pull/71,
I first commit the test code without fix for this error.
After confirming that it fails, I will push the fix.