### PR TITLE
fix travis build and add melodic and noetic test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     # install geckodriver for testing
     - ADDITIONAL_DEBS="firefox"
-    - BEFORE_INIT="apt-get update && apt-get install -y wget && wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
+    - BEFORE_INIT="apt-get update && apt-get install -y curl && curl -L -o /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-linux64.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && chmod +x geckodriver && cp -f geckodriver /usr/local/bin && geckodriver --version"
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - ADDITIONAL_DEBS="firefox"
     - BEFORE_INIT="apt-get update && apt-get install -y curl && curl -L -o /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-linux64.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && chmod +x geckodriver && cp -f geckodriver /usr/local/bin && geckodriver --version"
   matrix:
+    - CHECK_PYTHON3_COMPILE=true
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"
     - ROS_DISTRO="kinetic"
@@ -32,5 +33,6 @@ matrix:
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:
+  - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then python3 -m compileall .; exit $?; fi
   - .ci_config/travis.sh
 #  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     # install geckodriver for testing
     - ADDITIONAL_DEBS="firefox"
-    - BEFORE_SCRIPT="wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
+    - BEFORE_INIT="wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     # install geckodriver for testing
     - ADDITIONAL_DEBS="firefox"
-    - BEFORE_INIT="wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
+    - BEFORE_INIT="apt-get update && apt-get install -y wget && wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz -O /tmp/geckodriver.tar.gz && cd /tmp && tar xf geckodriver.tar.gz && cp -f geckodriver /usr/bin && geckodriver --version"
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,13 @@ env:
     - ROS_DISTRO="jade"
     - ROS_DISTRO="kinetic"
     - ROS_DISTRO="lunar"
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="noetic"
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: ROS_DISTRO="jade"
+    - env: ROS_DISTRO="lunar"
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   <run_depend>rosbridge_server</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rospack</run_depend>
-  <test_depend>phantomjs</test_depend>
   <test_depend>python-selenium-pip</test_depend>
   <test_depend>rostest</test_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<package>
+<package format="3">
   <name>roswww</name>
   <version>0.1.12</version>
   <description>Feathery lightweight web server for ROS, that is based on <a href = "http://www.tornadoweb.org/en/stable">Tornado</a> web server module.</description>
@@ -13,12 +12,14 @@
   <url type="repository">https://github.com/tork-a/roswww</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>python-catkin-pkg</build_depend>
-  <run_depend>rosbridge_server</run_depend>
-  <run_depend>rosbridge_server</run_depend>
-  <run_depend>rosgraph</run_depend>
-  <run_depend>rospack</run_depend>
-  <test_depend>python-selenium-pip</test_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rosgraph</exec_depend>
+  <exec_depend>rospack</exec_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-selenium-pip</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-selenium-pip</test_depend>
   <test_depend>rostest</test_depend>
   <export>
     <rosdoc config="rosdoc.yaml" />

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>rosgraph</exec_depend>
   <exec_depend>rospack</exec_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-selenium-pip</test_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-selenium-pip</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-selenium</test_depend>
   <test_depend>rostest</test_depend>
   <export>
     <rosdoc config="rosdoc.yaml" />

--- a/test/test_roswww.py
+++ b/test/test_roswww.py
@@ -36,13 +36,11 @@
 # Author: Isaac I.Y. Saito
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
-import os
 import rospy
 import rostest
 import unittest
 
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -53,13 +51,9 @@ class TestClient(unittest.TestCase):
     def setUp(self):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
-        try:
-            opts = webdriver.firefox.options.Options()
-            opts.set_headless(True)
-            self.browser = webdriver.Firefox(firefox_options=opts)
-        except WebDriverException:
-            rospy.logwarn("Failling back to PhantomJS driver")
-            self.browser = webdriver.PhantomJS()
+        opts = webdriver.firefox.options.Options()
+        opts.set_headless(True)
+        self.browser = webdriver.Firefox(firefox_options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)
         # maximize screen


### PR DESCRIPTION
I fix travis build and add melodic and noetic test.
I switch to use Firefox geckodriver because PhantomJS is stopped for further development and deprecated.

For noetic test, `python3-selenium` key is needed.
https://github.com/ros/rosdistro/pull/27358

- use `BEFORE_INIT` instead of `BEFORE_SCRIPT`
- use `curl` in `BEFORE_INIT`
- install `geckodriver==v0.28.0`
- add noetic and melodic build
- allow failure on lunar and jade build