### PR TITLE
Add single package mode

### DIFF
--- a/launch/roswww.launch
+++ b/launch/roswww.launch
@@ -2,6 +2,7 @@
   <arg name="name" default="roswww"/>
   <arg name="webpath" default="www"/> <!-- package webroot -->
   <arg name="cached" default="true"/>
+  <arg name="single_package" default=""/>
 
   <arg name="port" default="8085"/>
   <arg name="start_port" default="$(arg port)" />
@@ -9,5 +10,6 @@
 
   <node pkg="roswww" type="webserver.py" name="$(arg name)"
         args="--name $(arg name) --webpath $(arg webpath) --cached $(arg cached)
+              --single_package=$(arg single_package)
               --port $(arg port) --start_port $(arg start_port) --end_port $(arg end_port)" />
 </launch>

--- a/script/webserver.py
+++ b/script/webserver.py
@@ -47,18 +47,19 @@ def parse_argument(argv):
     parser.add_argument('-n', '--name', default=rospy.get_name(), help='Webserver name')
     parser.add_argument('-p', '--port', default=80, type=int, help='Webserver Port number')
     parser.add_argument('-w', '--webpath', default='www', help='package relative path to web pages')
+    parser.add_argument('-s', '--single_package', default='', help='package name for single package mode')
     parser.add_argument('--cached', default='true', help='static file is cached')
     parser.add_argument('--start_port', default=8000, type=int, help='setting up port scan range')
     parser.add_argument('--end_port', default=9000, type=int, help='setting up port scan range')
 
     parsed_args = parser.parse_args(argv)
     cached = False if parsed_args.cached in [0, False, 'false', 'False'] else True
-    return parsed_args.name, parsed_args.webpath, (parsed_args.port, parsed_args.start_port, parsed_args.end_port), cached
+    return parsed_args.name, parsed_args.webpath, (parsed_args.port, parsed_args.start_port, parsed_args.end_port), cached, parsed_args.single_package
 
 
 if __name__ == '__main__':
     rospy.init_node("webserver", disable_signals=True)
-    name, webpath, port, cached = parse_argument(rospy.myargv()[1:])
-    webserver = roswww.ROSWWWServer(name, webpath, port, cached)
+    name, webpath, port, cached, single = parse_argument(rospy.myargv()[1:])
+    webserver = roswww.ROSWWWServer(name, webpath, port, cached, single_package=single)
     webserver.loginfo("Initialised")
     webserver.spin()


### PR DESCRIPTION
We want to use single package mode (without package name).
You might think that if you don't need package names, you can use normal web server,
but if you want to handle Ctrl-C properly, we need own web server like roswww.